### PR TITLE
Update agent-config template for multiple dns resolvers

### DIFF
--- a/billi/ansible/agent-config.yaml.j2
+++ b/billi/ansible/agent-config.yaml.j2
@@ -9,7 +9,9 @@ hosts:
     dns-resolver:
       config:
         server:
-        - {{ gateway }}
+{% for ns in dns_resolver %}
+        - {{ ns }}
+{% endfor %}
     interfaces:
     - ethernet:
         auto-negotiation: true

--- a/billi/ansible/inventory.sample
+++ b/billi/ansible/inventory.sample
@@ -4,6 +4,8 @@ all:
     iso_url: http://192.168.122.1/agent.iso
     prefix: 24
     gateway: 192.168.128.1
+    dns_resolver:
+      - 192.168.128.1
     hosts:
     - ip: 192.168.128.11
       mac: de:ad:bb:ef:00:21


### PR DESCRIPTION
Update agent-config template to allow passing multiple dns resolvers different than default gw.