### PR TITLE
Update agent-config template for static dual stack node networking

### DIFF
--- a/billi/ansible/agent-config.yaml.j2
+++ b/billi/ansible/agent-config.yaml.j2
@@ -2,7 +2,7 @@ apiVersion: v1alpha1
 kind: AgentConfig
 metadata:
   name: billi
-rendezvousIP: {{ rendezvous_ip|default(hosts[0]['ip']) }}
+rendezvousIP: {{ rendezvous_ip|default(hosts[0]['ips'][0]['ip']) }}
 hosts:
 {% for host in hosts %}
 - hostname: {{ host['name']|default(cluster + "-" + loop.index0|string) }}
@@ -21,11 +21,13 @@ hosts:
         auto-negotiation: true
         duplex: full
         speed: 1000
-{{ '      ipv6' if ':' in host['ip'] else '      ipv4' }}:
+{% for int in host['ips'] %}
+{{ int['ip']|ipv6 | ternary('      ipv6','      ipv4') }}:
         address:
-        - ip: {{ host['ip'] }}
-          prefix-length: {{ prefix }}
+        - ip: {{ int['ip'] }}
+          prefix-length: {{ int['netmask'] }}
         enabled: true
+{% endfor %}
       mac-address: {{ host['mac'] }}
       mtu: 1500
       name: {{ host['nic']|default('ens3') }}
@@ -33,16 +35,13 @@ hosts:
       type: ethernet
     routes:
       config:
-{% if ':' not in host['ip'] %}
-      - destination: {{ machine_cidr }}
-        next-hop-address: {{ gateway }}
+{% for int in host['ips'] %}
+      - destination: {{ int['ip']|ipv6 | ternary('::/0', '0.0.0.0/0') }}
+        next-hop-address: {{ int['gateway']  }}
         next-hop-interface: {{ host['nic']|default('ens3') }}
-{% endif %}
-      - destination: {{ "::/0" if ':' in host['ip'] else "0.0.0.0/0" }}
-        next-hop-address: {{ gateway }}
-        next-hop-interface: {{ host['nic']|default('ens3') }}
-{% if ':' not in host['ip'] %}
+{% if int['ip']|ipv4 %}
         table-id: 254
 {% endif %}
         enabled: true
+{% endfor %}
 {% endfor %}

--- a/billi/ansible/install-config.yaml.j2
+++ b/billi/ansible/install-config.yaml.j2
@@ -2,6 +2,7 @@
 {% set cluster_network_ipv6 = {"cidr": "fd01::/48", "hostPrefix": 64} %}
 {% set service_network_ipv4 = ["172.30.0.0/16"] %}
 {% set service_network_ipv6 = ["fd02::/112"] %}
+{% set machine_networks = [] %}
 {% if dualstack|default(False) %}
 {% set cluster_networks = [cluster_network_ipv4] + [cluster_network_ipv6] %}
 {% set service_networks = service_network_ipv4 + service_network_ipv6 %}
@@ -12,6 +13,9 @@
 {% set cluster_networks = [cluster_network_ipv4] %}
 {% set service_networks = service_network_ipv4 %}
 {% endif %}
+{% for addr in hosts[0]['ips'] %}
+{% set machine_networks = machine_networks.append((addr.ip|string+'/'+addr.netmask|string)|ipaddr('network/prefix')) %}
+{% endfor %}
 
 apiVersion: v1
 baseDomain: {{ domain }}

--- a/billi/ansible/inventory.sample
+++ b/billi/ansible/inventory.sample
@@ -2,24 +2,39 @@ all:
   vars:
     openshift_install_url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/latest-4.12/openshift-install-linux.tar.gz
     iso_url: http://192.168.122.1/agent.x86_64.iso
-    prefix: 24
-    gateway: 192.168.128.1
     dns_resolver:
       - 192.168.128.1
     hosts:
-    - ip: 192.168.128.11
+    - ips:
+      - ip: 192.168.128.11
+        netmask: 24
+        gateway: 192.168.128.1
+#      - ip: 2620:52:0:1303::21
+#        netmask: 64
+#        gateway: 2620:52:0:1303::1
       mac: de:ad:bb:ef:00:21
       bmc_url: http://192.168.122.1:8000/redfish/v1/Systems/11111111-1111-1111-1111-111111111181
 #     disk: vdd
-    - ip: 192.168.128.12
+    - ips:
+      - ip: 192.168.128.12
+        netmask: 24
+        gateway: 192.168.128.1
+#      - ip: 2620:52:0:1303::22
+#        netmask: 64
+#        gateway: 2620:52:0:1303::1
       mac: de:ad:bb:ef:00:22
       bmc_url: http://192.168.122.1:8000/redfish/v1/Systems/11111111-1111-1111-1111-111111111182
-    - ip: 192.168.128.13
+    - ips:
+      - ip: 192.168.128.13
+        netmask: 24
+        gateway: 192.168.128.1
+#      - ip: 2620:52:0:1303::23
+#        netmask: 64
+#        gateway: 2620:52:0:1303::1
       mac: de:ad:bb:ef:00:23
       bmc_url: http://192.168.122.1:8000/redfish/v1/Systems/11111111-1111-1111-1111-111111111183
     cluster: billi
     domain: karmalabs.corp
-    machine_networks: [192.168.128.0/24]
     masters: 3
     workers: 0
     api_vip: 192.168.128.253

--- a/billi/ansible/inventory_ipv6.sample
+++ b/billi/ansible/inventory_ipv6.sample
@@ -4,23 +4,30 @@ all:
     # pull_secret_file: /root/openshift_pull.json
     iso_url: http://192.168.122.1/agent.x86_64.iso
     prefix: 64
-    gateway: 2620:52:0:1303::1
     dns_resolver:
     - 2620:52:0:1303::1
     hosts:
-    - ip: 2620:52:0:1303::21
+    - ips:
+      - ip: 2620:52:0:1303::21
+        netmask: 64
+        gateway: 2620:52:0:1303::1
       mac: de:ad:bb:ef:00:21
       bmc_url: http://192.168.122.1:8000/redfish/v1/Systems/11111111-1111-1111-1111-111111111181
 #     disk: vdd
-    - ip: 2620:52:0:1303::22
+    - ips:
+      - ip: 2620:52:0:1303::22
+        netmask: 64
+        gateway: 2620:52:0:1303::1
       mac: de:ad:bb:ef:00:22
       bmc_url: http://192.168.122.1:8000/redfish/v1/Systems/11111111-1111-1111-1111-111111111182
-    - ip: 2620:52:0:1303::23
+    - ips:
+      - ip: 2620:52:0:1303::23
+        netmask: 64
+        gateway: 2620:52:0:1303::1
       mac: de:ad:bb:ef:00:23
       bmc_url: http://192.168.122.1:8000/redfish/v1/Systems/11111111-1111-1111-1111-111111111183
     cluster: billi
     domain: karmalabs.corp
-    machine_networks: [2620:52:0:1303::/64]
     masters: 3
     workers: 0
     api_vip: 2620:52:0:1303::2


### PR DESCRIPTION
This change updates the agent-config template to allow setting dual stack(both ipv4 and ipv6 addresses) on the nodes networks.

- removes the machine_networks variable from the inventory file and determines the machine_networks subnets based on the address/netmask set in the ip attributes

- allows passing multiple ip addresses/netmask/gateways per host

- removes the route to the machine_cidr which seems redundant as the nodes have a direct route since they have an address from the machine_cidr subnet
